### PR TITLE
Added glossary page for internal name conversions

### DIFF
--- a/docs/internal-names-glossary/_category_.json
+++ b/docs/internal-names-glossary/_category_.json
@@ -1,0 +1,7 @@
+{
+    "label": "Glossary",
+    "link": {
+      "type": "generated-index"
+    }
+  }
+  

--- a/docs/internal-names-glossary/glossary.md
+++ b/docs/internal-names-glossary/glossary.md
@@ -1,0 +1,77 @@
+# Glossary of Internal Names
+
+## Room Reward Types
+Internal Name | Canonical Name | Note
+--- | --- | ---
+&lt;GodName&gt;Upgrade | Boon from &lt;GodName&gt; |
+Devotion | Trial of the Gods | 
+Trial | Chaos boon |
+SpellDrop | Selene boon | 
+TalentDrop | Path of Stars (Hex powerup) | 
+StackUpgrade | Pom of power |
+MaxHealthDrop | Centaur Heart (Max health increase) |
+MaxManaDrop | Soul tonic (Max Magick increase) |
+RoomMoneyDrop | Obols (gold) | 
+WeaponUpgrade | Hammer |
+Shop | Charon Shop |
+Story | NPC room | 
+--------|--------|--------
+Gift | Nectar of the Gods |
+MemPointsCommonDrop | Psyche |
+MetaCardPointsCommonDrop | Ash |
+MetaCurrencyDrop | Bones | 
+--------|--------|--------
+&lt;Element&gt;Boost | single element reward from Ephyra side rooms | 
+EmptyMaxHealthSmallDrop | small Centaur Soul (max health increase with no healing) from Ephyra side rooms
+MaxHealthDropSmall | small Centaur Heart (max health increase) from Ephyra side rooms
+MaxManaDropSmall | small Soul Tonic (max Magick increase) from Ephyra side rooms
+RoomMoneyTinyDrop | small Obol (gold) drop from Ephyra side rooms
+
+## Tools, Weapons and Aspects
+Internal Name | Canonical Name | Note
+--- | --- | ---
+WeaponStaffSwing | Descura, the Witch's Staff / Staff basic attack
+BaseStaffAspect | Aspect of Melinoe for the staff |
+StaffClearCastAspect | Aspect of Circe for the staff | 
+StaffSelfHitAspect | Aspect of Momus for the staff |
+--------|--------|--------
+WeaponDagger | Lim and Oros, the Sister Blades |
+DaggerBackstabAspect | Aspect of Melinoe for the sister blades |
+DaggerBlockAspect | Aspect of Artemis for the sister blades |
+DaggerHomingThrowAspect | Aspect of Pan for the sister blades |
+--------|--------|--------
+WeaponAxe | Zorophet, the Moonstone Axe |
+AxeArmCastAspect | Aspect of Charon for the moonstone axe |
+AxePerfectCriticalAspect | Aspect of Thanatos for the moonstone axe |
+AxeRecoveryAspect | Aspect of Melinoe for the moonstone axe |
+--------|--------|--------
+WeaponTorch | Ygnium, the Umbral Flames (torches) |
+TorchSpecialDurationAspect | Aspect of Melinoe for the umbral flames | 
+TorchDetonateAspect | Aspect of Moros for the umbral flames |
+TorchSprintRecallAspect | Aspect of Eos for the umbral flames | 
+--------|--------|--------
+WeaponLob | Revaal, the Argent Skull |
+LobAmmoBoostAspect | Aspect of Melinoe for the argent skull |
+LobCloseAttackAspect | Aspect of Medea for the argent skull |
+LobImpulseAspect | Aspect of Persephone for the argent skull |
+--------|--------|--------
+ExcorcismPoint | Tablet of Peace shade |
+FishingPoint | Rod of Fishing interactable |
+HarvestPoint | Gather plant interactable |
+PickaxePoint | Crescent Pick interactable |
+ShovelPoint | Silver Spade (Shovel) interactable |
+
+## Miscellaneous
+Internal Name | Canonical Name | Note
+--- | --- | ---
+Bounty | Pitch-Black Stone trial | 
+ClockworkGoal | Main path numbered Tartarus Room |
+FieldsRewardFinder | Golden Bough |
+Mana | Magick |
+Quest | Objective on the Fated List |
+RewardCage / Cage | Reward location in Fields of Mourning | 
+SecretSpawn | Chaos entrance |
+ShrineUpgrade | Bonus provided via Arcana |
+Spell | Hex |
+TimeChallengeSwitch | Infernal Trove |
+UnityTrait | Infusion boon (elemental threshold boon) | 

--- a/docs/internal-names-glossary/glossary.md
+++ b/docs/internal-names-glossary/glossary.md
@@ -55,7 +55,7 @@ LobAmmoBoostAspect | Aspect of Melinoe for the argent skull |
 LobCloseAttackAspect | Aspect of Medea for the argent skull |
 LobImpulseAspect | Aspect of Persephone for the argent skull |
 --------|--------|--------
-ExcorcismPoint | Tablet of Peace shade |
+ExorcismPoint | Tablet of Peace shade |
 FishingPoint | Rod of Fishing interactable |
 HarvestPoint | Gather plant interactable |
 PickaxePoint | Crescent Pick interactable |


### PR DESCRIPTION
Formatted as a table for now, but may not be the cleanest styling.  Wanted to get a page and some base content in, so its lower effort for others to contribute as they encounter internal names