### PR TITLE
Fix audio guide to recommend 2D events instead of 3D

### DIFF
--- a/docs/creating-mods/audio/adding-sounds-music.md
+++ b/docs/creating-mods/audio/adding-sounds-music.md
@@ -52,9 +52,7 @@ These `.bank` files are stored in the `Content/Audio/Desktop` folder in your Had
 
 Use the template FMOD studio project linked above and add your assets to the project.
 
-For music tracks, you will want to create each event as a `2D Timeline` in most cases.
-Using the `3D timeline` adds a Spatializer to the event, and can cause the event to not play if e.g. this is a Music Maker song and the player loads a save in the Training Grounds.
-Unless you have a good reason to go with a 3D event, stick with 2D.
+For music tracks, you must create each event as a `2D Timeline` to prevent playback issues in certain situations.
 
 :::info[Looping]
 If you are adding music or sounds that should loop, select the event in FMOD Studio, right-click the timeline/preview of the event and select `New Loop Region`.

--- a/docs/creating-mods/audio/adding-sounds-music.md
+++ b/docs/creating-mods/audio/adding-sounds-music.md
@@ -51,7 +51,10 @@ These `.bank` files are stored in the `Content/Audio/Desktop` folder in your Had
 ## Creating soundbanks
 
 Use the template FMOD studio project linked above and add your assets to the project.
-For music tracks, you will want to create each event as a `3D Timeline` in most cases.
+
+For music tracks, you will want to create each event as a `2D Timeline` in most cases.
+Using the `3D timeline` adds a Spatializer to the event, and can cause the event to not play if e.g. this is a Music Maker song and the player loads a save in the Training Grounds.
+Unless you have a good reason to go with a 3D event, stick with 2D.
 
 :::info[Looping]
 If you are adding music or sounds that should loop, select the event in FMOD Studio, right-click the timeline/preview of the event and select `New Loop Region`.


### PR DESCRIPTION
The guide incorrectly recommended using 3D events, which can cause playback to not start/be silent in certain circumstances.